### PR TITLE
add : createdBy, updatedBy 자동화

### DIFF
--- a/src/main/java/com/sparta/msa_exam/orderservicepractice/domain/region/domain/Region.java
+++ b/src/main/java/com/sparta/msa_exam/orderservicepractice/domain/region/domain/Region.java
@@ -1,11 +1,14 @@
 package com.sparta.msa_exam.orderservicepractice.domain.region.domain;
 
+import com.sparta.msa_exam.orderservicepractice.domain.region.domain.dto.request.CreateRegionRequest;
 import com.sparta.msa_exam.orderservicepractice.global.base.domain.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.UUID;
 
@@ -14,9 +17,21 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "regions")
+@SQLRestriction(value = "deleted_at is NULL")
 public class Region extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    public Region(String name) {
+        this.name = name;
+    }
+
+    public static Region from(@Valid CreateRegionRequest request) {
+        return new Region(request.name());
+    }
 }

--- a/src/main/java/com/sparta/msa_exam/orderservicepractice/global/base/domain/BaseEntity.java
+++ b/src/main/java/com/sparta/msa_exam/orderservicepractice/global/base/domain/BaseEntity.java
@@ -5,7 +5,9 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -23,12 +25,14 @@ public abstract class BaseEntity {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
+    @CreatedBy
     private String createdBy;
 
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
+    @LastModifiedBy
     private String updatedBy;
 
     @Column(name = "deleted_at")

--- a/src/main/java/com/sparta/msa_exam/orderservicepractice/global/config/JpaConfig.java
+++ b/src/main/java/com/sparta/msa_exam/orderservicepractice/global/config/JpaConfig.java
@@ -1,9 +1,19 @@
 package com.sparta.msa_exam.orderservicepractice.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        // TODO. SecurityContext 에서 꺼내온 Authentication 에서 nickname 추출
+        return () -> Optional.of("닉네임");
+    }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[BE] feat: ~~(#issueNum)
[AN/STAFF] feat: ~~(#issueNum)
[AN/USER] fix: ~~(#issueNum)
-->

## 📌 필독 내용
- soft delete 도 삭제 일시를 자동화로 구현 가능하지만, deleteBy는 하드코딩으로 손 수 해줘야 하기 때문에
- `SQLDelete` 어노테이션은 사용하지 않고, 직접 구현하는걸로 하고 `SQLRestriction` 으로 검색 제약조건을 걸어주는걸로 사용
- 즉, soft delete 는 직접 구현해서 사용할것

## ✨ PR 세부 내용
- JpaAuditing 에서 제공하는 어노테이션으로 createdBy, updatedBy 자동화를 구성.
- 현재는 테스트로 "닉네임" 으로 하드코딩되어있지만, security 구현 후 context에서 해당되는 닉네임을 가져오는걸로 수정할 예정.
<!-- 수정/추가한 내용을 적어주세요. -->
